### PR TITLE
Add an option to disable writing to .p4ticket during authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ sonar.perforce.useSsl | Use SSL protocol (p4javassl://) to connect to server | f
 sonar.perforce.charset | Character set used for translation of unicode files (P4CHARSET)	 
 sonar.perforce.sockSoTimeout | Perforce socket read timeout for communicating with the Perforce service (milliseconds) | 30000 (30s)
 sonar.perforce.clientImpersonatedHostname | Name of the host computer to impersonate (P4HOST) |
+sonar.perforce.writeTickets | Do not write p4 tickets file when authenticating | false
 
 ## Known Limitations
 * No auto-detection since nothing in workspace seems to show this is under Perforce control management (like .git folder for Git workspace).
 * Blame is not executed in parallel since we are not confident in the thread safety of p4java library.
 
-## Developper informations
-The plugin use the p4java pure Java implementation of Perforce client: http://www.perforce.com/perforce/doc.current/manuals/p4java/01_p4java.html
+## Developer information
+The plugin uses the p4java pure Java implementation of Perforce client: http://www.perforce.com/perforce/doc.current/manuals/p4java/01_p4java.html

--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceConfiguration.java
@@ -37,6 +37,7 @@ import java.util.List;
 public class PerforceConfiguration implements BatchComponent {
 
   private static final String FALSE = "false";
+  private static final String TRUE = "true";
   private static final String CATEGORY_PERFORCE = "Perforce";
   static final String PORT_PROP_KEY = "sonar.perforce.port";
   private static final String USESSL_PROP_KEY = "sonar.perforce.useSsl";
@@ -46,6 +47,7 @@ public class PerforceConfiguration implements BatchComponent {
   private static final String CLIENT_IMPERSONATED_HOST_PROP_KEY = "sonar.perforce.clientImpersonatedHostname";
   private static final String CHARSET_PROP_KEY = "sonar.perforce.charset";
   private static final String SOCKSOTIMEOUT_PROP_KEY = "sonar.perforce.sockSoTimeout";
+  private static final String WRITE_TICKETS = "sonar.perforce.writeTickets";
 
   private final Settings settings;
 
@@ -128,6 +130,16 @@ public class PerforceConfiguration implements BatchComponent {
         .category(CoreProperties.CATEGORY_SCM)
         .subCategory(CATEGORY_PERFORCE)
         .index(7)
+        .build(),
+      PropertyDefinition.builder(WRITE_TICKETS)
+        .name("Do not write to tickets file when authenticating")
+        .description("Perforce client locks the ticket file during writes, this can cause concurrent analyses to fail. Set this to false to disable this behavior.")
+        .type(PropertyType.BOOLEAN)
+        .defaultValue(TRUE)
+        .onQualifiers(Qualifiers.PROJECT)
+        .category(CoreProperties.CATEGORY_SCM)
+        .subCategory(CATEGORY_PERFORCE)
+        .index(8)
         .build());
   }
 
@@ -169,4 +181,7 @@ public class PerforceConfiguration implements BatchComponent {
     return settings.getInt(SOCKSOTIMEOUT_PROP_KEY);
   }
 
+  public boolean writeTickets() {
+    return settings.getBoolean(WRITE_TICKETS);
+  }
 }

--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceExecutor.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceExecutor.java
@@ -30,6 +30,7 @@ import com.perforce.p4java.impl.generic.client.ClientView.ClientViewMapping;
 import com.perforce.p4java.impl.mapbased.rpc.RpcPropertyDefs;
 import com.perforce.p4java.impl.mapbased.rpc.sys.helper.RpcSystemFileCommandsHelper;
 import com.perforce.p4java.option.UsageOptions;
+import com.perforce.p4java.option.server.LoginOptions;
 import com.perforce.p4java.option.server.TrustOptions;
 import com.perforce.p4java.server.IOptionsServer;
 import com.perforce.p4java.server.ServerFactory;
@@ -126,7 +127,8 @@ public class PerforceExecutor {
         if (!isLogin(server)) {
           // Login to the server with a password.
           // Password can be null if it is not needed (i.e. SSO logins).
-          server.login(config.password(), null);
+          LoginOptions options = new LoginOptions(false, config.writeTickets());
+          server.login(config.password(), options);
         }
       }
     } catch (URISyntaxException e) {

--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforcePluginTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforcePluginTest.java
@@ -27,6 +27,6 @@ public class PerforcePluginTest {
 
   @Test
   public void getExtensions() {
-    assertThat(new PerforcePlugin().getExtensions()).hasSize(11);
+    assertThat(new PerforcePlugin().getExtensions()).hasSize(12);
   }
 }


### PR DESCRIPTION
P4Java and the p4 command line tool both lock this file during updates. This can cause the scm plugin analysis to fail when analyses are conducted concurrently on the same machine (i.e., one or more may fail with permission denied errors). This pull request adds an option to disable writing to the tickets file.