### PR TITLE
Concurrent blame with more unit tests and degraded annotation options when retrying.

### DIFF
--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
@@ -24,6 +24,7 @@ import com.perforce.p4java.core.file.FileSpecOpStatus;
 import com.perforce.p4java.core.file.IFileAnnotation;
 import com.perforce.p4java.core.file.IFileRevisionData;
 import com.perforce.p4java.core.file.IFileSpec;
+import com.perforce.p4java.exception.P4JavaException;
 import com.perforce.p4java.option.server.GetFileAnnotationsOptions;
 import com.perforce.p4java.option.server.GetRevisionHistoryOptions;
 import com.perforce.p4java.server.IOptionsServer;
@@ -33,13 +34,20 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.scm.BlameCommand.BlameOutput;
 import org.sonar.api.batch.scm.BlameLine;
 
+import static org.assertj.core.api.Fail.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -163,4 +171,47 @@ public class PerforceBlameCommandTest {
     verify(blameOutput).blameResult(inputFile, Arrays.asList(line, line));
   }
 
+  @Test
+  public void testRetryBlameThrowsAfterRetriesExhausted() throws Exception {
+    BlameOutput blameOutput = mock(BlameOutput.class);
+    IOptionsServer server = mock(IOptionsServer.class);
+    InputFile inputFile = mock(InputFile.class);
+    PerforceBlameCommand command = new PerforceBlameCommand(mock(PerforceConfiguration.class));
+
+    doThrow(new P4JavaException()).when(server).getFileAnnotations(anyListOf(IFileSpec.class), any(GetFileAnnotationsOptions.class));
+    try {
+      command.tryBlame(inputFile, server, blameOutput);
+      fail("Exception should have been re-thrown.");
+    } catch (P4JavaException e) {
+      verify(server, times(PerforceBlameCommand.MAX_ATTEMPTS)).getFileAnnotations(anyListOf(IFileSpec.class), any(GetFileAnnotationsOptions.class));
+    }
+  }
+
+  @Test
+  public void testDegradeAnnotationOptionsForRetry() throws Exception {
+    BlameOutput blameOutput = mock(BlameOutput.class);
+    IOptionsServer server = mock(IOptionsServer.class);
+    InputFile inputFile = mock(InputFile.class);
+    PerforceBlameCommand command = new PerforceBlameCommand(mock(PerforceConfiguration.class));
+    when(server.getFileAnnotations(anyListOf(IFileSpec.class), argThat(isFollowIntegrations(true))))
+      .thenThrow(new P4JavaException());
+    when(server.getFileAnnotations(anyListOf(IFileSpec.class), argThat(isFollowIntegrations(false))))
+      .thenReturn(Collections.<IFileAnnotation>emptyList());
+    command.tryBlame(inputFile, server, blameOutput);
+  }
+
+  private Matcher<GetFileAnnotationsOptions> isFollowIntegrations(final boolean follow) {
+    return new BaseMatcher<GetFileAnnotationsOptions>() {
+      @Override
+      public boolean matches(Object o) {
+        return o instanceof GetFileAnnotationsOptions
+            && ((GetFileAnnotationsOptions) o).isFollowAllIntegrations() == follow;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("matches follow integration annotation option");
+      }
+    };
+  }
 }


### PR DESCRIPTION
This change is based on a branch made from [this pull request](https://github.com/SonarQubeCommunity/sonar-scm-perforce/pull/12). For reasons I cannot explain, a few of the files in our code base cannot be annotated when 'ignore white space' or 'follow integration' options are set (this is also true for the p4 command line tool, not just the p4java library). With this change, the plugin will disable these options before the next attempt to annotate a file. I also added a couple of unit tests for this change.